### PR TITLE
Proposed fixes to deprecations in action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,7 @@ runs:
       with:
         fetch-depth: 1
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-region: eu-west-1
         role-to-assume: ${{ inputs.role-to-assume }}
@@ -41,7 +41,7 @@ runs:
         elif [ "${{ github.event_name }}" = "push" ]; then
           IMAGE_TAG="sha-${GITHUB_SHA::7}"
         fi
-        echo ::set-output name=image-tag::${IMAGE_TAG}
+        echo "image-tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
     - name: Build, tag, and push image to Amazon ECR
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}


### PR DESCRIPTION
[Over in this repo](https://github.com/moj-analytical-services/airflow-image-upload-test), I have demoed how these changes would work in practice. This change is aimed at fixing deprecation warnings related to node.js versions and github actions `set-output` calls.